### PR TITLE
Feat/llm.txt for MCP

### DIFF
--- a/src/kedro_mcp/server.py
+++ b/src/kedro_mcp/server.py
@@ -6,6 +6,26 @@ mcp = FastMCP(
     "MCP server to help AI assistants interact with Kedro",
 )
 
+@mcp.prompt(title="Kedro Assistant Guidance")
+def kedro_guidance() -> str:
+    """
+    Guidance for AI assistants when helping with Kedro-related questions.
+    """
+    return """
+    When helping users with Kedro-related questions, always refer to the comprehensive Kedro documentation first.
+    
+    **Key Documentation Resources:**
+    - For Kedro framework documentation, see: https://docs.kedro.org/en/stable/llm.txt
+    - For comprehensive kedro-dataset documentation, see: https://docs.kedro.org/projects/kedro-datasets/en/stable/llms.txt  
+    - For pipeline visualisation documentation, see: https://docs.kedro.org/projects/kedro-viz/en/stable/llms.txt
+    
+    Always check these resources when users ask about:
+    - Kedro project setup, configuration, or best practices
+    - Data catalogs, datasets, or data loading/saving
+    - Pipeline creation, visualization, or deployment
+    - Kedro plugins, extensions, or integrations
+    """
+
 @mcp.tool(title="Health Check")
 def health_check() -> dict:
     """
@@ -16,4 +36,26 @@ def health_check() -> dict:
         "status": "ok",
         "message": "kedro-mcp server is up and running 🚀",
         "version": "0.0.1.dev0",
+    }
+
+@mcp.tool(title="Get Kedro Documentation")
+def get_kedro_documentation() -> dict:
+    """
+    Get Kedro documentation links for comprehensive information.
+    
+    Returns:
+        Dictionary with links to Kedro documentation resources for LLMs.
+    """
+    return {
+        "message": "For comprehensive Kedro documentation, please read the following resources:",
+        "documentation_links": {
+            "kedro": "https://docs.kedro.org/en/stable/llm.txt",
+            "kedro_datasets": "https://docs.kedro.org/projects/kedro-datasets/en/stable/llms.txt", 
+            "kedro_viz": "https://docs.kedro.org/projects/kedro-viz/en/stable/llms.txt"
+        },
+        "instructions": [
+            "For Kedro framework documentation, see: https://docs.kedro.org/en/stable/llm.txt",
+            "For comprehensive kedro-dataset documentation, see: https://docs.kedro.org/projects/kedro-datasets/en/stable/llms.txt",
+            "For pipeline visualisation documentation, see: https://docs.kedro.org/projects/kedro-viz/en/stable/llms.txt",
+        ]
     }

--- a/src/kedro_mcp/server.py
+++ b/src/kedro_mcp/server.py
@@ -48,11 +48,6 @@ def get_kedro_documentation() -> dict:
     """
     return {
         "message": "For comprehensive Kedro documentation, please read the following resources:",
-        "documentation_links": {
-            "kedro": "https://docs.kedro.org/en/stable/llm.txt",
-            "kedro_datasets": "https://docs.kedro.org/projects/kedro-datasets/en/stable/llms.txt", 
-            "kedro_viz": "https://docs.kedro.org/projects/kedro-viz/en/stable/llms.txt"
-        },
         "instructions": [
             "For Kedro framework documentation, see: https://docs.kedro.org/en/stable/llm.txt",
             "For comprehensive kedro-dataset documentation, see: https://docs.kedro.org/projects/kedro-datasets/en/stable/llms.txt",


### PR DESCRIPTION
## Description:
As part of this ticket https://github.com/kedro-org/kedro/issues/5070, Sajid and I have already added llm.txt files to the docs (merged, but not yet released). These will eventually live here, but links aren’t valid until the next release:

- https://docs.kedro.org/en/stable/llm.txt 
- https://docs.kedro.org/projects/kedro-datasets/en/stable/llms.txt 
- https://docs.kedro.org/projects/kedro-viz/en/stable/llms.txt

For adding these files in our MCP server, there are 2 approaches:

- **Tooling-based approach**: Build a tool to explicitly instruct the LLM to fetch information from the llm.txt files first, before looking elsewhere.
- **Prompt-only approach** (simpler): Create a prompt with clear instructions and guidance for the LLM to prioritise and use Kedro’s llm.txt files when answering Kedro-related questions.

We don’t need both approaches. I’d propose going with option 2 (prompt-only) as the simplest and fastest way forward.